### PR TITLE
Correct spelling mistake in variable name

### DIFF
--- a/depcopy.sh
+++ b/depcopy.sh
@@ -235,7 +235,7 @@ echo "You may need to copy other application files - depending on your use case.
 ########################
 unset $EXECUTABLE_BINARY
 unset $DEPENDENCIES
-unset $ABLOSUTE_AS_RELATIVE
+unset $ABSOLUTE_AS_RELATIVE
 unset $COPY_MODE
 unset $SYMLINK_FOLLOW_MODE
 ########################


### PR DESCRIPTION
The variable ABSOLUTE_AS_RELATIVE is incorrectly referenced as ABLOSUTE_AS_RELATIVE on line 238.